### PR TITLE
fix: Diet,Food,Dietfood 엔티티 재정의,ocr 결과물 저장될 때 memberUuid 같이 저장

### DIFF
--- a/src/main/java/com/f_log/flog/diet/controller/DietController.java
+++ b/src/main/java/com/f_log/flog/diet/controller/DietController.java
@@ -18,36 +18,26 @@ public class DietController {
     private final DietService dietService;
 
     @PostMapping("/new")
-    public ResponseEntity<DietDto> createDiet(@RequestBody CreateDietRequest createDietRequest) {
-        UUID uuid = dietService.saveDiet(createDietRequest);
-        DietDto dietDto = dietService.findDietByUuid(uuid);
+    public ResponseEntity<DietDto> createDiet(@RequestBody CreateDietRequest request) {
+        DietDto dietDto = dietService.createDiet(request);
         return new ResponseEntity<>(dietDto, HttpStatus.CREATED);
     }
 
-    @GetMapping("/{uuid}")
-    public ResponseEntity<DietDto> findDietByUuid(@PathVariable UUID uuid) {
-        DietDto dietDto = dietService.findDietByUuid(uuid);
+    @GetMapping("/{dietUuid}")
+    public ResponseEntity<DietDto> getDiet(@PathVariable UUID dietUuid) {
+        DietDto dietDto = dietService.getDietByUuid(dietUuid);
         return ResponseEntity.ok(dietDto);
     }
 
-    @PutMapping("/{uuid}")
-    public ResponseEntity<DietDto> updateDiet(@PathVariable UUID uuid, @RequestBody UpdateDietRequest updateDietRequest) {
-        boolean updated = dietService.updateDiet(uuid, updateDietRequest);
-        if (updated) {
-            DietDto updatedDiet = dietService.findDietByUuid(uuid);
-            return ResponseEntity.ok(updatedDiet);
-        } else {
-            return ResponseEntity.notFound().build();
-        }
+    @PutMapping("/{dietUuid}")
+    public ResponseEntity<DietDto> updateDiet(@PathVariable UUID dietUuid, @RequestBody UpdateDietRequest request) {
+        DietDto dietDto = dietService.updateDiet(dietUuid, request);
+        return ResponseEntity.ok(dietDto);
     }
 
-    @DeleteMapping("/{uuid}")
-    public ResponseEntity<Void> deleteDiet(@PathVariable UUID uuid) {
-        boolean deleted = dietService.deleteDiet(uuid);
-        if (deleted) {
-            return ResponseEntity.ok().build();
-        } else {
-            return ResponseEntity.notFound().build();
-        }
+    @DeleteMapping("/{dietUuid}")
+    public ResponseEntity<Void> deleteDiet(@PathVariable UUID dietUuid) {
+        dietService.deleteDiet(dietUuid);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/f_log/flog/diet/domain/Diet.java
+++ b/src/main/java/com/f_log/flog/diet/domain/Diet.java
@@ -1,6 +1,7 @@
 package com.f_log.flog.diet.domain;
 
 import com.f_log.flog.dietfeedback.domain.DietFeedback;
+import com.f_log.flog.dietfood.domain.DietFood;
 import com.f_log.flog.food.domain.Food;
 import com.f_log.flog.global.domain.BaseEntity;
 import com.f_log.flog.member.domain.Member;
@@ -25,11 +26,6 @@ public class Diet extends BaseEntity {
     @Column(name = "diet_id")
     private Long id;
 
-    /* TODO: s3 url 추가 */
-
-    @OneToMany(mappedBy = "diet", cascade = CascadeType.ALL)
-    private List<Food> foods = new ArrayList<>();
-
     @Column(name = "total_carbohydrate")
     private int totalCarbohydrate;
 
@@ -48,8 +44,8 @@ public class Diet extends BaseEntity {
     @Column(name = "meal_date")
     private LocalDateTime mealDate;
 
-    @Column(name = "uuid", columnDefinition = "BINARY(16)")
-    private UUID uuid;
+    @Column(name = "diet_uuid", columnDefinition = "BINARY(16)")
+    private UUID dietUuid;
 
     @Enumerated(EnumType.STRING)
     private MealType mealType;
@@ -62,9 +58,12 @@ public class Diet extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToMany(mappedBy = "diet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DietFood> dietFoods = new ArrayList<>();
+
     // TODO: add Foods, implement total nutrient calculation method using foods
     @Builder
-    public Diet(UUID uuid,
+    public Diet(UUID dietUuid,
                 Member member,
                 int totalCarbohydrate,
                 int totalProtein,
@@ -73,7 +72,7 @@ public class Diet extends BaseEntity {
                 int totalCholesterol,
                 MealType mealType,
                 LocalDateTime mealDate) {
-        this.uuid = uuid;
+        this.dietUuid = dietUuid;
         this.member = member;
         this.totalCarbohydrate = totalCarbohydrate;
         this.totalProtein = totalProtein;
@@ -82,10 +81,6 @@ public class Diet extends BaseEntity {
         this.totalCholesterol = totalCholesterol;
         this.mealType = mealType;
         this.mealDate = mealDate;
-    }
-
-    private void addFoods(Food food) {
-        foods.add(food);
     }
 
     public void updateTotalCarbohydrate(int totalCarbohydrate) {

--- a/src/main/java/com/f_log/flog/diet/dto/DietDto.java
+++ b/src/main/java/com/f_log/flog/diet/dto/DietDto.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 @Getter
 @Builder
 public class DietDto {
-    private UUID uuid;
+    private UUID dietUuid;
     private UUID memberUuid;
     private int totalCarbohydrate;
     private int totalProtein;

--- a/src/main/java/com/f_log/flog/diet/dto/DietMapper.java
+++ b/src/main/java/com/f_log/flog/diet/dto/DietMapper.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 public class DietMapper {
     public DietDto toDto(Diet diet) {
         return DietDto.builder()
-                .uuid(diet.getUuid())
+                .dietUuid(diet.getDietUuid())
                 .memberUuid(diet.getMember().getUuid())
                 .totalCarbohydrate(diet.getTotalCarbohydrate())
                 .totalProtein(diet.getTotalProtein())

--- a/src/main/java/com/f_log/flog/diet/repository/DietRepository.java
+++ b/src/main/java/com/f_log/flog/diet/repository/DietRepository.java
@@ -1,10 +1,11 @@
 package com.f_log.flog.diet.repository;
 
 import com.f_log.flog.diet.domain.Diet;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
-    Diet findDietByUuid(UUID uuid);
+    Optional<Diet> findByDietUuidAndIsDeletedFalse(UUID dietUuid);
 }

--- a/src/main/java/com/f_log/flog/diet/service/DietService.java
+++ b/src/main/java/com/f_log/flog/diet/service/DietService.java
@@ -6,9 +6,9 @@ import com.f_log.flog.diet.dto.DietDto;
 import com.f_log.flog.diet.dto.DietMapper;
 import com.f_log.flog.diet.dto.UpdateDietRequest;
 import com.f_log.flog.diet.repository.DietRepository;
-import com.f_log.flog.food.repository.FoodRepository;
 import com.f_log.flog.member.domain.Member;
 import com.f_log.flog.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,63 +21,60 @@ public class DietService {
 
     private final DietRepository dietRepository;
     private final MemberRepository memberRepository;
-    private final FoodRepository foodRepository;
     private final DietMapper dietMapper;
 
-    public DietDto findDietByUuid(UUID uuid) {
-        Diet diet = dietRepository.findDietByUuid(uuid);
+    public DietDto getDietByUuid(UUID dietUuid) {
+        Diet diet = dietRepository.findByDietUuidAndIsDeletedFalse(dietUuid)
+                .orElseThrow(() -> new EntityNotFoundException("Diet not found"));
         return dietMapper.toDto(diet);
     }
 
     @Transactional
-    public UUID saveDiet(CreateDietRequest createDietRequest) {
-        UUID memberUuid = createDietRequest.getMemberUuid();
-        Member member = memberRepository.findByUuidAndIsDeletedFalse(memberUuid);
+    public DietDto createDiet(CreateDietRequest request) {
+        Member member = memberRepository.findByUuidAndIsDeletedFalse(request.getMemberUuid());
+        if (member == null) {
+            throw new EntityNotFoundException("Member not found");
+        }
 
-        UUID uuid = UUID.randomUUID();
+        UUID dietUuid = UUID.randomUUID();
+
         Diet diet = Diet.builder()
-                .uuid(uuid)
+                .dietUuid(dietUuid)
                 .member(member)
-                .totalCarbohydrate(createDietRequest.getTotalCarbohydrate())
-                .totalProtein(createDietRequest.getTotalProtein())
-                .totalFat(createDietRequest.getTotalFat())
-                .totalSodium(createDietRequest.getTotalSodium())
-                .totalCholesterol(createDietRequest.getTotalCholesterol())
-                .mealType(createDietRequest.getMealType())
-                .mealDate(createDietRequest.getMealDate())
+                .totalCarbohydrate(request.getTotalCarbohydrate())
+                .totalProtein(request.getTotalProtein())
+                .totalFat(request.getTotalFat())
+                .totalSodium(request.getTotalSodium())
+                .totalCholesterol(request.getTotalCholesterol())
+                .mealType(request.getMealType())
+                .mealDate(request.getMealDate())
                 .build();
         dietRepository.save(diet);
-        return uuid;
+        return dietMapper.toDto(diet);
     }
 
     @Transactional
-    public boolean updateDiet(UUID uuid, UpdateDietRequest updateDietRequest) {
-        Diet diet = dietRepository.findDietByUuid(uuid);
+    public DietDto updateDiet(UUID dietUuid, UpdateDietRequest request) {
+        Diet diet = dietRepository.findByDietUuidAndIsDeletedFalse(dietUuid)
+                .orElseThrow(() -> new EntityNotFoundException("Diet not found"));
         if (diet != null) {
-            diet.updateTotalCarbohydrate(updateDietRequest.getTotalCarbohydrate());
-            diet.updateTotalSodium(updateDietRequest.getTotalSodium());
-            diet.updateTotalProtein(updateDietRequest.getTotalProtein());
-            diet.updateTotalFat(updateDietRequest.getTotalFat());
-            diet.updateTotalCholesterol(updateDietRequest.getTotalCholesterol());
-            diet.updateMealDate(updateDietRequest.getMealDate());
-            diet.updateMealType(updateDietRequest.getMealType());
-            dietRepository.save(diet);
-            return true;
-        } else {
-            return false;
+            diet.updateTotalCarbohydrate(request.getTotalCarbohydrate());
+            diet.updateTotalSodium(request.getTotalSodium());
+            diet.updateTotalProtein(request.getTotalProtein());
+            diet.updateTotalFat(request.getTotalFat());
+            diet.updateTotalCholesterol(request.getTotalCholesterol());
+            diet.updateMealDate(request.getMealDate());
+            diet.updateMealType(request.getMealType());
         }
+        dietRepository.save(diet);
+        return dietMapper.toDto(diet);
     }
 
     @Transactional
-    public boolean deleteDiet(UUID uuid) {
-        Diet diet = dietRepository.findDietByUuid(uuid);
-        if (diet != null) {
-            diet.setDeleted();
-            dietRepository.save(diet);
-            return true;
-        } else {
-            return false;
-        }
+    public void deleteDiet (UUID dietUuid) {
+        Diet diet = dietRepository.findByDietUuidAndIsDeletedFalse(dietUuid)
+                .orElseThrow(() -> new EntityNotFoundException("Diet not found"));
+        diet.setDeleted();
+        dietRepository.save(diet);
     }
-
 }

--- a/src/main/java/com/f_log/flog/dietfeedback/service/DietFeedbackService.java
+++ b/src/main/java/com/f_log/flog/dietfeedback/service/DietFeedbackService.java
@@ -7,6 +7,7 @@ import com.f_log.flog.dietfeedback.dto.DietFeedbackDto;
 import com.f_log.flog.dietfeedback.dto.DietFeedbackMapper;
 import com.f_log.flog.dietfeedback.dto.DietFeedbackRequest;
 import com.f_log.flog.dietfeedback.repository.DietFeedbackRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,8 @@ public class DietFeedbackService {
 
     @Transactional
     public DietFeedbackDto createDietFeedback(UUID dietUuid, DietFeedbackRequest dietFeedbackRequest) {
-        Diet diet = dietRepository.findDietByUuid(dietUuid);
+        Diet diet = dietRepository.findByDietUuidAndIsDeletedFalse(dietUuid)
+                .orElseThrow(() -> new EntityNotFoundException("Diet not found with UUID: " + dietUuid));
 
         if (diet != null) {
             boolean feedbackExists = dietFeedbackRepository.existsByDietAndIsDeletedFalse(diet);

--- a/src/main/java/com/f_log/flog/dietfood/controller/DietFoodController.java
+++ b/src/main/java/com/f_log/flog/dietfood/controller/DietFoodController.java
@@ -1,0 +1,40 @@
+package com.f_log.flog.dietfood.controller;
+
+import com.f_log.flog.dietfood.dto.DietFoodRequestDTO;
+import com.f_log.flog.dietfood.dto.DietFoodResponseDTO;
+import com.f_log.flog.dietfood.service.DietFoodService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/dietfoods")
+@RequiredArgsConstructor
+public class DietFoodController {
+    private final DietFoodService dietFoodService;
+
+    @PostMapping("/new")
+    public ResponseEntity<DietFoodResponseDTO> createDietFood(@RequestBody DietFoodRequestDTO requestDTO) {
+        DietFoodResponseDTO responseDTO = dietFoodService.createDietFood(requestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DietFoodResponseDTO> getDietFood(@PathVariable Long id) {
+        DietFoodResponseDTO responseDTO = dietFoodService.findDietFood(id);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<DietFoodResponseDTO> updateDietFood(@PathVariable Long id, @RequestBody DietFoodRequestDTO requestDTO) {
+        DietFoodResponseDTO responseDTO = dietFoodService.updateDietFood(id, requestDTO);
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDietFood(@PathVariable Long id) {
+        dietFoodService.deleteDietFood(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/f_log/flog/dietfood/domain/DietFood.java
+++ b/src/main/java/com/f_log/flog/dietfood/domain/DietFood.java
@@ -1,0 +1,55 @@
+package com.f_log.flog.dietfood.domain;
+
+import com.f_log.flog.diet.domain.Diet;
+import com.f_log.flog.food.domain.Food;
+import com.f_log.flog.global.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DietFood extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diet_id")
+    private Diet diet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_id")
+    private Food food;
+
+    private int quantity; // 수량
+
+    private String notes; // 비고
+
+    @Builder
+    public DietFood(Diet diet, Food food, int quantity, String notes) {
+        this.diet = diet;
+        this.food = food;
+        this.quantity = quantity;
+        this.notes = notes;
+    }
+
+    // 수량 업데이트 메소드
+    public void updateQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    // 비고 업데이트 메소드
+    public void updateNotes(String notes) {
+        this.notes = notes;
+    }
+}

--- a/src/main/java/com/f_log/flog/dietfood/dto/DietFoodRequestDTO.java
+++ b/src/main/java/com/f_log/flog/dietfood/dto/DietFoodRequestDTO.java
@@ -1,0 +1,11 @@
+package com.f_log.flog.dietfood.dto;
+
+import lombok.Data;
+
+@Data
+public class DietFoodRequestDTO {
+    private Long dietId;
+    private Long foodId;
+    private int quantity;
+    private String notes;
+}

--- a/src/main/java/com/f_log/flog/dietfood/dto/DietFoodResponseDTO.java
+++ b/src/main/java/com/f_log/flog/dietfood/dto/DietFoodResponseDTO.java
@@ -1,0 +1,14 @@
+package com.f_log.flog.dietfood.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DietFoodResponseDTO {
+    private Long id;
+    private Long dietId;
+    private Long foodId;
+    private int quantity;
+    private String notes;
+}

--- a/src/main/java/com/f_log/flog/dietfood/repository/DietFoodRepository.java
+++ b/src/main/java/com/f_log/flog/dietfood/repository/DietFoodRepository.java
@@ -1,0 +1,9 @@
+package com.f_log.flog.dietfood.repository;
+
+import com.f_log.flog.dietfood.domain.DietFood;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DietFoodRepository extends JpaRepository<DietFood, Long> {
+    Optional<DietFood> findByIdAndIsDeletedFalse(Long id);
+}

--- a/src/main/java/com/f_log/flog/dietfood/service/DietFoodService.java
+++ b/src/main/java/com/f_log/flog/dietfood/service/DietFoodService.java
@@ -1,0 +1,88 @@
+package com.f_log.flog.dietfood.service;
+
+import com.f_log.flog.diet.domain.Diet;
+import com.f_log.flog.diet.repository.DietRepository;
+import com.f_log.flog.dietfood.domain.DietFood;
+import com.f_log.flog.dietfood.dto.DietFoodRequestDTO;
+import com.f_log.flog.dietfood.dto.DietFoodResponseDTO;
+import com.f_log.flog.dietfood.repository.DietFoodRepository;
+import com.f_log.flog.food.domain.Food;
+import com.f_log.flog.food.repository.FoodRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DietFoodService {
+    private final DietFoodRepository dietFoodRepository;
+    private final DietRepository dietRepository;
+    private final FoodRepository foodRepository;
+
+    @Transactional
+    public DietFoodResponseDTO createDietFood(DietFoodRequestDTO requestDTO) {
+        Diet diet = dietRepository.findById(requestDTO.getDietId())
+                .orElseThrow(() -> new EntityNotFoundException("Diet not found with id: " + requestDTO.getDietId()));
+        Food food = foodRepository.findById(requestDTO.getFoodId())
+                .orElseThrow(() -> new EntityNotFoundException("Food not found with id: " + requestDTO.getFoodId()));
+
+        DietFood dietFood = DietFood.builder()
+                .diet(diet)
+                .food(food)
+                .quantity(requestDTO.getQuantity())
+                .notes(requestDTO.getNotes())
+                .build();
+        DietFood savedDietFood = dietFoodRepository.save(dietFood);
+
+        return DietFoodResponseDTO.builder()
+                .id(savedDietFood.getId())
+                .dietId(savedDietFood.getDiet().getId())
+                .foodId(savedDietFood.getFood().getId())
+                .quantity(savedDietFood.getQuantity())
+                .notes(savedDietFood.getNotes())
+                .build();
+    }
+
+    @Transactional
+    public DietFoodResponseDTO findDietFood(Long id) {
+        DietFood dietFood = dietFoodRepository.findByIdAndIsDeletedFalse(id)
+                .orElseThrow(() -> new EntityNotFoundException("DietFood not found with id: " + id));
+
+        return DietFoodResponseDTO.builder()
+                .id(dietFood.getId())
+                .dietId(dietFood.getDiet().getId())
+                .foodId(dietFood.getFood().getId())
+                .quantity(dietFood.getQuantity())
+                .notes(dietFood.getNotes())
+                .build();
+    }
+
+    @Transactional
+    public DietFoodResponseDTO updateDietFood(Long id, DietFoodRequestDTO requestDTO) {
+        DietFood dietFood = dietFoodRepository.findByIdAndIsDeletedFalse(id)
+                .orElseThrow(() -> new EntityNotFoundException("DietFood not found with id: " + id));
+
+        dietFood.updateQuantity(requestDTO.getQuantity());
+        dietFood.updateNotes(requestDTO.getNotes());
+
+        dietFood = dietFoodRepository.save(dietFood);
+
+        return DietFoodResponseDTO.builder()
+                .id(dietFood.getId())
+                .dietId(dietFood.getDiet().getId())
+                .foodId(dietFood.getFood().getId())
+                .quantity(dietFood.getQuantity())
+                .notes(dietFood.getNotes())
+                .build();
+    }
+
+
+    @Transactional
+    public void deleteDietFood(Long id) {
+        DietFood dietFood = dietFoodRepository.findByIdAndIsDeletedFalse(id)
+                .orElseThrow(() -> new EntityNotFoundException("DietFood not found with id: " + id));
+        dietFood.setDeleted();
+        dietFoodRepository.save(dietFood);
+    }
+}

--- a/src/main/java/com/f_log/flog/food/controller/FoodController.java
+++ b/src/main/java/com/f_log/flog/food/controller/FoodController.java
@@ -20,11 +20,11 @@ public class FoodController {
 
     @PostMapping("/new")
     public ResponseEntity<FoodDto> createFood(@RequestBody @Valid FoodRequestDto foodRequestDto) {
-        Food food = foodRequestDto.toEntity();
-        foodService.saveFood(food);
+        Food food = foodService.saveFood(foodRequestDto);
         FoodDto foodDto = foodMapper.toDto(food);
         return new ResponseEntity<>(foodDto, HttpStatus.CREATED);
     }
+
 
     @GetMapping("/{id}")
     public ResponseEntity<FoodDto> getFoodById(@PathVariable Long id) {

--- a/src/main/java/com/f_log/flog/food/domain/Food.java
+++ b/src/main/java/com/f_log/flog/food/domain/Food.java
@@ -1,6 +1,5 @@
 package com.f_log.flog.food.domain;
 
-import com.f_log.flog.diet.domain.Diet;
 import com.f_log.flog.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -19,10 +18,6 @@ public class Food extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "food_id")
     private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diet_id")
-    private Diet diet;
 
     private String foodName;
 

--- a/src/main/java/com/f_log/flog/food/dto/FoodRequestDto.java
+++ b/src/main/java/com/f_log/flog/food/dto/FoodRequestDto.java
@@ -1,5 +1,6 @@
 package com.f_log.flog.food.dto;
 
+import com.f_log.flog.diet.domain.Diet;
 import com.f_log.flog.food.domain.Food;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,9 @@ public class FoodRequestDto {
     private final int fat;
     private final int sodium;
     private final int cholesterol;
+    private Long dietId;
 
-    public Food toEntity() {
+    public Food toEntity(Diet diet) {
         return Food.builder()
                 .foodName(foodName)
                 .carbohydrate(carbohydrate)
@@ -22,6 +24,7 @@ public class FoodRequestDto {
                 .fat(fat)
                 .sodium(sodium)
                 .cholesterol(cholesterol)
+                .diet(diet)
                 .build();
     }
 }

--- a/src/main/java/com/f_log/flog/food/dto/FoodRequestDto.java
+++ b/src/main/java/com/f_log/flog/food/dto/FoodRequestDto.java
@@ -14,9 +14,8 @@ public class FoodRequestDto {
     private final int fat;
     private final int sodium;
     private final int cholesterol;
-    private Long dietId;
 
-    public Food toEntity(Diet diet) {
+    public Food toEntity() {
         return Food.builder()
                 .foodName(foodName)
                 .carbohydrate(carbohydrate)
@@ -24,7 +23,6 @@ public class FoodRequestDto {
                 .fat(fat)
                 .sodium(sodium)
                 .cholesterol(cholesterol)
-                .diet(diet)
                 .build();
     }
 }

--- a/src/main/java/com/f_log/flog/food/service/FoodService.java
+++ b/src/main/java/com/f_log/flog/food/service/FoodService.java
@@ -1,8 +1,11 @@
 package com.f_log.flog.food.service;
 
+import com.f_log.flog.diet.domain.Diet;
+import com.f_log.flog.diet.repository.DietRepository;
 import com.f_log.flog.food.domain.Food;
 import com.f_log.flog.food.dto.FoodRequestDto;
 import com.f_log.flog.food.repository.FoodRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,10 +17,31 @@ import java.util.List;
 public class FoodService {
 
     private final FoodRepository foodRepository;
+    private final DietRepository dietRepository;
 
     @Transactional
-    public void saveFood(Food food) {
-        foodRepository.save(food);
+    public Food saveFood(FoodRequestDto foodRequestDto) {
+        // foodRequestDto에서 dietId가 null인지 확인
+        if (foodRequestDto.getDietId() == null) {
+            throw new IllegalArgumentException("dietId must not be null");
+        }
+
+        // dietId로 Diet 엔티티 조회
+        Diet diet = dietRepository.findById(foodRequestDto.getDietId())
+                .orElseThrow(() -> new EntityNotFoundException("Diet not found with id: " + foodRequestDto.getDietId()));
+
+        // Food 엔티티 생성
+        Food food = Food.builder()
+                .foodName(foodRequestDto.getFoodName())
+                .carbohydrate(foodRequestDto.getCarbohydrate())
+                .protein(foodRequestDto.getProtein())
+                .fat(foodRequestDto.getFat())
+                .sodium(foodRequestDto.getSodium())
+                .cholesterol(foodRequestDto.getCholesterol())
+                .diet(diet)
+                .build();
+
+        return foodRepository.save(food);
     }
 
     public Food findFood(Long foodId) {

--- a/src/main/java/com/f_log/flog/food/service/FoodService.java
+++ b/src/main/java/com/f_log/flog/food/service/FoodService.java
@@ -1,11 +1,8 @@
 package com.f_log.flog.food.service;
 
-import com.f_log.flog.diet.domain.Diet;
-import com.f_log.flog.diet.repository.DietRepository;
 import com.f_log.flog.food.domain.Food;
 import com.f_log.flog.food.dto.FoodRequestDto;
 import com.f_log.flog.food.repository.FoodRepository;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,30 +14,10 @@ import java.util.List;
 public class FoodService {
 
     private final FoodRepository foodRepository;
-    private final DietRepository dietRepository;
 
     @Transactional
     public Food saveFood(FoodRequestDto foodRequestDto) {
-        // foodRequestDto에서 dietId가 null인지 확인
-        if (foodRequestDto.getDietId() == null) {
-            throw new IllegalArgumentException("dietId must not be null");
-        }
-
-        // dietId로 Diet 엔티티 조회
-        Diet diet = dietRepository.findById(foodRequestDto.getDietId())
-                .orElseThrow(() -> new EntityNotFoundException("Diet not found with id: " + foodRequestDto.getDietId()));
-
-        // Food 엔티티 생성
-        Food food = Food.builder()
-                .foodName(foodRequestDto.getFoodName())
-                .carbohydrate(foodRequestDto.getCarbohydrate())
-                .protein(foodRequestDto.getProtein())
-                .fat(foodRequestDto.getFat())
-                .sodium(foodRequestDto.getSodium())
-                .cholesterol(foodRequestDto.getCholesterol())
-                .diet(diet)
-                .build();
-
+        Food food = foodRequestDto.toEntity();
         return foodRepository.save(food);
     }
 


### PR DESCRIPTION
fix: Diet,Food,Dietfood 엔티티 재정의,ocr 결과물 저장될 때 memberUuid 같이 저장

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✅] 기능 추가
-[✅] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/#52 -> main

### 변경 사항
