### PR TITLE
feat: Exercise 엔티티를 활용한 Feedback 생성 및 DietFeedback 재정의

### DIFF
--- a/src/main/java/com/f_log/flog/diet/controller/DietController.java
+++ b/src/main/java/com/f_log/flog/diet/controller/DietController.java
@@ -1,14 +1,19 @@
 package com.f_log.flog.diet.controller;
 
 import com.f_log.flog.diet.dto.CreateDietRequest;
+import com.f_log.flog.diet.dto.DailyIntakeDto;
 import com.f_log.flog.diet.dto.DietDto;
 import com.f_log.flog.diet.dto.UpdateDietRequest;
 import com.f_log.flog.diet.service.DietService;
+import com.f_log.flog.member.dto.MemberResponseDto;
+import com.f_log.flog.member.service.MemberService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @RestController
@@ -16,7 +21,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DietController {
     private final DietService dietService;
-    private final RestTemplate restTemplate;
+    private final MemberService memberService;
 
     @PostMapping("/new")
     public ResponseEntity<DietDto> createDiet(@RequestBody CreateDietRequest request) {
@@ -40,5 +45,14 @@ public class DietController {
     public ResponseEntity<Void> deleteDiet(@PathVariable UUID dietUuid) {
         dietService.deleteDiet(dietUuid);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/daily-intake")
+    public ResponseEntity<DailyIntakeDto> getTotalIntakeForDay(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+                                                               @RequestParam("memberId") UUID memberId) {
+        MemberResponseDto memberDto = memberService.getMemberByUuid(memberId);
+
+        DailyIntakeDto dailyIntake = dietService.getTotalIntakeForDay(date, memberDto);
+        return ResponseEntity.ok(dailyIntake);
     }
 }

--- a/src/main/java/com/f_log/flog/diet/controller/DietController.java
+++ b/src/main/java/com/f_log/flog/diet/controller/DietController.java
@@ -7,7 +7,6 @@ import com.f_log.flog.diet.dto.UpdateDietRequest;
 import com.f_log.flog.diet.service.DietService;
 import com.f_log.flog.member.dto.MemberResponseDto;
 import com.f_log.flog.member.service.MemberService;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
@@ -49,8 +48,8 @@ public class DietController {
 
     @GetMapping("/daily-intake")
     public ResponseEntity<DailyIntakeDto> getTotalIntakeForDay(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-                                                               @RequestParam("memberId") UUID memberId) {
-        MemberResponseDto memberDto = memberService.getMemberByUuid(memberId);
+                                                               @RequestParam("memberUuid") UUID memberUuid) {
+        MemberResponseDto memberDto = memberService.getMemberByUuid(memberUuid);
 
         DailyIntakeDto dailyIntake = dietService.getTotalIntakeForDay(date, memberDto);
         return ResponseEntity.ok(dailyIntake);

--- a/src/main/java/com/f_log/flog/diet/domain/Diet.java
+++ b/src/main/java/com/f_log/flog/diet/domain/Diet.java
@@ -1,6 +1,5 @@
 package com.f_log.flog.diet.domain;
 
-import com.f_log.flog.dietfeedback.domain.DietFeedback;
 import com.f_log.flog.dietfood.domain.DietFood;
 import com.f_log.flog.global.domain.BaseEntity;
 import com.f_log.flog.member.domain.Member;
@@ -54,9 +53,6 @@ public class Diet extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private MealType mealType;
-
-    @OneToOne(mappedBy = "diet", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private DietFeedback dietFeedback;
 
     // member와의 N:1 관계
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/f_log/flog/diet/dto/DailyIntakeDto.java
+++ b/src/main/java/com/f_log/flog/diet/dto/DailyIntakeDto.java
@@ -1,0 +1,16 @@
+package com.f_log.flog.diet.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DailyIntakeDto {
+    private int totalCarbohydrate;
+    private int totalProtein;
+    private int totalFat;
+    private int totalSodium;
+    private int totalCholesterol;
+    private int totalSugars;
+    private int totalCalories;
+}

--- a/src/main/java/com/f_log/flog/diet/repository/DietRepository.java
+++ b/src/main/java/com/f_log/flog/diet/repository/DietRepository.java
@@ -11,5 +11,5 @@ import java.util.UUID;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
     Optional<Diet> findByDietUuidAndIsDeletedFalse(UUID dietUuid);
-    List<Diet> findByMealDateAndMemberUuid(LocalDate mealDate, UUID memberId);
+    List<Diet> findByMealDateAndMemberUuidAndIsDeletedFalse(LocalDate mealDate, UUID memberId);
 }

--- a/src/main/java/com/f_log/flog/diet/repository/DietRepository.java
+++ b/src/main/java/com/f_log/flog/diet/repository/DietRepository.java
@@ -1,6 +1,9 @@
 package com.f_log.flog.diet.repository;
 
 import com.f_log.flog.diet.domain.Diet;
+
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +11,5 @@ import java.util.UUID;
 
 public interface DietRepository extends JpaRepository<Diet, Long> {
     Optional<Diet> findByDietUuidAndIsDeletedFalse(UUID dietUuid);
+    List<Diet> findByMealDateAndMemberUuid(LocalDate mealDate, UUID memberId);
 }

--- a/src/main/java/com/f_log/flog/diet/service/DietService.java
+++ b/src/main/java/com/f_log/flog/diet/service/DietService.java
@@ -83,7 +83,7 @@ public class DietService {
     }
 
     public DailyIntakeDto getTotalIntakeForDay(LocalDate date, MemberResponseDto memberDto) {
-        List<Diet> diets = dietRepository.findByMealDateAndMemberUuid(date, memberDto.getUuid());
+        List<Diet> diets = dietRepository.findByMealDateAndMemberUuidAndIsDeletedFalse(date, memberDto.getUuid());
 
         int totalCarbohydrate = 0;
         int totalProtein = 0;

--- a/src/main/java/com/f_log/flog/diet/service/DietService.java
+++ b/src/main/java/com/f_log/flog/diet/service/DietService.java
@@ -82,8 +82,8 @@ public class DietService {
         dietRepository.save(diet);
     }
 
-    public DailyIntakeDto getTotalIntakeForDay(LocalDate day, MemberResponseDto memberDto) {
-        List<Diet> diets = dietRepository.findByMealDateAndMemberUuid(day, memberDto.getUuid());
+    public DailyIntakeDto getTotalIntakeForDay(LocalDate date, MemberResponseDto memberDto) {
+        List<Diet> diets = dietRepository.findByMealDateAndMemberUuid(date, memberDto.getUuid());
 
         int totalCarbohydrate = 0;
         int totalProtein = 0;

--- a/src/main/java/com/f_log/flog/diet/service/DietService.java
+++ b/src/main/java/com/f_log/flog/diet/service/DietService.java
@@ -1,18 +1,18 @@
 package com.f_log.flog.diet.service;
 
 import com.f_log.flog.diet.domain.Diet;
-import com.f_log.flog.diet.dto.CreateDietRequest;
-import com.f_log.flog.diet.dto.DietDto;
-import com.f_log.flog.diet.dto.DietMapper;
-import com.f_log.flog.diet.dto.UpdateDietRequest;
+import com.f_log.flog.diet.dto.*;
 import com.f_log.flog.diet.repository.DietRepository;
 import com.f_log.flog.member.domain.Member;
+import com.f_log.flog.member.dto.MemberResponseDto;
 import com.f_log.flog.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -80,5 +80,39 @@ public class DietService {
                 .orElseThrow(() -> new EntityNotFoundException("Diet not found"));
         diet.setDeleted();
         dietRepository.save(diet);
+    }
+
+    public DailyIntakeDto getTotalIntakeForDay(LocalDate day, MemberResponseDto memberDto) {
+        List<Diet> diets = dietRepository.findByMealDateAndMemberUuid(day, memberDto.getUuid());
+
+        int totalCarbohydrate = 0;
+        int totalProtein = 0;
+        int totalFat = 0;
+        int totalSodium = 0;
+        int totalCholesterol = 0;
+        int totalSugars = 0;
+        int totalCalories = 0;
+
+        for (Diet diet : diets) {
+            totalCarbohydrate += diet.getTotalCarbohydrate();
+            totalProtein += diet.getTotalProtein();
+            totalFat += diet.getTotalFat();
+            totalSodium += diet.getTotalSodium();
+            totalCholesterol += diet.getTotalCholesterol();
+            totalSugars += diet.getTotalSugars();
+            totalCalories += diet.getTotalCalories();
+        }
+
+        DailyIntakeDto dailyIntake = DailyIntakeDto.builder()
+                .totalCarbohydrate(totalCarbohydrate)
+                .totalProtein(totalProtein)
+                .totalFat(totalFat)
+                .totalSodium(totalSodium)
+                .totalCholesterol(totalCholesterol)
+                .totalSugars(totalSugars)
+                .totalCalories(totalCalories)
+                .build();
+
+        return dailyIntake;
     }
 }

--- a/src/main/java/com/f_log/flog/dietfeedback/domain/DietFeedback.java
+++ b/src/main/java/com/f_log/flog/dietfeedback/domain/DietFeedback.java
@@ -22,14 +22,9 @@ public class DietFeedback extends BaseEntity{
     @Column(name = "diet_feedback", length = 10000)
     private String dietFeedback;
 
-    @OneToOne
-    @JoinColumn(name = "diet_id")
-    private Diet diet;
-
     @Builder
-    public DietFeedback(String dietFeedback, Diet diet) {
+    public DietFeedback(String dietFeedback) {
         this.dietFeedback = dietFeedback;
-        this.diet = diet;
     }
 
     public void setDietFeedback(String dietFeedback) {

--- a/src/main/java/com/f_log/flog/dietfeedback/dto/DietFeedbackRequest.java
+++ b/src/main/java/com/f_log/flog/dietfeedback/dto/DietFeedbackRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @Getter
@@ -12,6 +13,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DietFeedbackRequest {
-    private UUID dietUuid;
+    private UUID memberUuid;
+    private LocalDate date;
     private String dietFeedback;
 }

--- a/src/main/java/com/f_log/flog/dietfeedback/repository/DietFeedbackRepository.java
+++ b/src/main/java/com/f_log/flog/dietfeedback/repository/DietFeedbackRepository.java
@@ -11,5 +11,4 @@ import java.util.Optional;
 public interface DietFeedbackRepository extends JpaRepository<DietFeedback, Long> {
 
     Optional<DietFeedback> findByIdAndIsDeletedFalse(Long id);
-    boolean existsByDietAndIsDeletedFalse(Diet diet);
 }

--- a/src/main/java/com/f_log/flog/dietfeedback/service/DietFeedbackService.java
+++ b/src/main/java/com/f_log/flog/dietfeedback/service/DietFeedbackService.java
@@ -23,23 +23,9 @@ public class DietFeedbackService {
 
     @Transactional
     public DietFeedbackDto createDietFeedback(DietFeedbackRequest dietFeedbackRequest) {
-        UUID dietUuid = dietFeedbackRequest.getDietUuid();
-        Diet diet = dietRepository.findByDietUuidAndIsDeletedFalse(dietUuid)
-                .orElseThrow(() -> new EntityNotFoundException("Diet not found with UUID: " + dietUuid));
-
-        if (diet != null) {
-            boolean feedbackExists = dietFeedbackRepository.existsByDietAndIsDeletedFalse(diet);
-
-            if (!feedbackExists) {
-                DietFeedback dietFeedback = new DietFeedback(dietFeedbackRequest.getDietFeedback(), diet);
-                dietFeedbackRepository.save(dietFeedback);
-                return dietFeedbackMapper.toDto(dietFeedback);
-            } else {
-                throw new RuntimeException("DietFeedback for Inbody with UUID " + dietUuid + " already exists.");
-            }
-        } else {
-            throw new RuntimeException("Diet with UUID " + dietUuid + " not found or has been deleted.");
-        }
+        DietFeedback dietFeedback = new DietFeedback(dietFeedbackRequest.getDietFeedback());
+        dietFeedbackRepository.save(dietFeedback);
+        return dietFeedbackMapper.toDto(dietFeedback);
     }
 
     @Transactional

--- a/src/main/java/com/f_log/flog/exercise/controller/ExerciseController.java
+++ b/src/main/java/com/f_log/flog/exercise/controller/ExerciseController.java
@@ -38,9 +38,8 @@ public class ExerciseController {
      */
     @GetMapping("/{memberUuid}")
     public ResponseEntity<ExerciseResponseDto> getExercise(@PathVariable UUID memberUuid) {
-        return exerciseService.getExercise(memberUuid)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        ExerciseResponseDto exercise = exerciseService.getExercise(memberUuid);
+        return ResponseEntity.ok(exercise);
     }
 
     /**

--- a/src/main/java/com/f_log/flog/exercise/service/ExerciseService.java
+++ b/src/main/java/com/f_log/flog/exercise/service/ExerciseService.java
@@ -70,9 +70,10 @@ public class ExerciseService {
      * @param memberUuid 회원의 UUID
      * @return 운동 정보 DTO
      */
-    public Optional<ExerciseResponseDto> getExercise(UUID memberUuid) {
-        return exerciseRepository.findByMemberUuidAndIsDeletedFalse(memberUuid)
-                .map(exerciseMapper::toDto);
+    public ExerciseResponseDto getExercise(UUID memberUuid) {
+        Exercise exercise = exerciseRepository.findByMemberUuidAndIsDeletedFalse(memberUuid)
+                .orElseThrow(() -> new IllegalArgumentException("Exercise not found for this member."));
+        return exerciseMapper.toDto(exercise);
     }
 
     /**

--- a/src/main/java/com/f_log/flog/gpt/GptController.java
+++ b/src/main/java/com/f_log/flog/gpt/GptController.java
@@ -1,5 +1,6 @@
 package com.f_log.flog.gpt;
 
+import com.f_log.flog.diet.dto.DailyIntakeDto;
 import com.f_log.flog.diet.dto.DietDto;
 import com.f_log.flog.diet.service.DietService;
 import com.f_log.flog.dietfeedback.dto.DietFeedbackDto;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 @RestController
@@ -31,13 +33,12 @@ public class GptController {
     private final ExerciseService exerciseService;
 
     @PostMapping("/diet-feedback")
-    public ResponseEntity<DietFeedbackDto> createDietFeedback(@RequestBody UUID dietUuid) {
-        DietDto foundDiet = dietService.getDietByUuid(dietUuid);
-        UUID memberUuid = foundDiet.getMemberUuid();
+    public ResponseEntity<DietFeedbackDto> createDietFeedback(@RequestBody LocalDate date, UUID memberUuid) {
         MemberResponseDto foundMember = memberService.getMemberByUuid(memberUuid);
+        DailyIntakeDto totalIntakeForDay = dietService.getTotalIntakeForDay(date, foundMember);
         InbodyResponseDto foundInbody = inbodyService.getLatestInbodyOfMember(memberUuid);
         ExerciseResponseDto foundExercise = exerciseService.getExercise(memberUuid);
-        return gptService.createDietFeedback(dietUuid, foundDiet, foundMember, foundInbody, foundExercise);
+        return gptService.createDietFeedback(date, foundMember, totalIntakeForDay, foundInbody, foundExercise);
     }
 
     @PostMapping("/inbody-feedback")

--- a/src/main/java/com/f_log/flog/gpt/GptController.java
+++ b/src/main/java/com/f_log/flog/gpt/GptController.java
@@ -3,6 +3,8 @@ package com.f_log.flog.gpt;
 import com.f_log.flog.diet.dto.DietDto;
 import com.f_log.flog.diet.service.DietService;
 import com.f_log.flog.dietfeedback.dto.DietFeedbackDto;
+import com.f_log.flog.exercise.dto.ExerciseResponseDto;
+import com.f_log.flog.exercise.service.ExerciseService;
 import com.f_log.flog.inbody.dto.InbodyResponseDto;
 import com.f_log.flog.inbody.service.InbodyService;
 import com.f_log.flog.inbodyfeedback.dto.InbodyFeedbackResponseDto;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @RestController
@@ -26,6 +29,7 @@ public class GptController {
     private final MemberService memberService;
     private final InbodyService inbodyService;
     private final GptService gptService;
+    private final ExerciseService exerciseService;
 
     @PostMapping("/diet-feedback")
     public ResponseEntity<DietFeedbackDto> createDietFeedback(@RequestBody UUID dietUuid) {
@@ -33,13 +37,15 @@ public class GptController {
         UUID memberUuid = foundDiet.getMemberUuid();
         MemberResponseDto foundMember = memberService.getMemberByUuid(memberUuid);
         InbodyResponseDto foundInbody = inbodyService.getLatestInbodyOfMember(memberUuid);
-        return gptService.createDietFeedback(dietUuid, foundDiet, foundMember, foundInbody);
+        ExerciseResponseDto foundExercise = exerciseService.getExercise(memberUuid);
+        return gptService.createDietFeedback(dietUuid, foundDiet, foundMember, foundInbody, foundExercise);
     }
 
     @PostMapping("/inbody-feedback")
     public ResponseEntity<InbodyFeedbackResponseDto> createInbodyFeedback(@RequestBody UUID inbodyUuid) {
         InbodyResponseDto foundInbody = inbodyService.getInbodyByUuid(inbodyUuid);
         MemberResponseDto foundMember = memberService.getMemberByUuid(foundInbody.getMemberUuid());
-        return gptService.createInbodyFeedback(inbodyUuid, foundInbody, foundMember);
+        ExerciseResponseDto foundExercise = exerciseService.getExercise(foundMember.getUuid());
+        return gptService.createInbodyFeedback(inbodyUuid, foundInbody, foundMember, foundExercise);
     }
 }

--- a/src/main/java/com/f_log/flog/gpt/GptController.java
+++ b/src/main/java/com/f_log/flog/gpt/GptController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @RestController

--- a/src/main/java/com/f_log/flog/gpt/GptService.java
+++ b/src/main/java/com/f_log/flog/gpt/GptService.java
@@ -2,6 +2,7 @@ package com.f_log.flog.gpt;
 
 import com.f_log.flog.diet.dto.DietDto;
 import com.f_log.flog.dietfeedback.dto.DietFeedbackDto;
+import com.f_log.flog.exercise.dto.ExerciseResponseDto;
 import com.f_log.flog.inbody.dto.InbodyResponseDto;
 import com.f_log.flog.inbodyfeedback.dto.InbodyFeedbackResponseDto;
 import com.f_log.flog.member.dto.MemberResponseDto;
@@ -20,13 +21,13 @@ public class GptService {
 
     private final RestTemplate restTemplate;
 
-    public ResponseEntity<DietFeedbackDto> createDietFeedback(UUID dietUuid, DietDto dietDto, MemberResponseDto memberResponseDto, InbodyResponseDto inbodyResponseDto) {
-        Map<String, Object> dataMap = createDietDataMap(dietUuid, dietDto, memberResponseDto, inbodyResponseDto);
+    public ResponseEntity<DietFeedbackDto> createDietFeedback(UUID dietUuid, DietDto dietDto, MemberResponseDto memberResponseDto, InbodyResponseDto inbodyResponseDto, ExerciseResponseDto exerciseResponseDto) {
+        Map<String, Object> dataMap = createDietDataMap(dietUuid, dietDto, memberResponseDto, inbodyResponseDto, exerciseResponseDto);
         ResponseEntity<DietFeedbackDto> responseEntity = exchangeDietData(dataMap);
         return responseEntity;
     }
 
-    private Map<String, Object> createDietDataMap(UUID dietUuid, DietDto dietDto, MemberResponseDto memberResponseDto, InbodyResponseDto inbodyResponseDto) {
+    private Map<String, Object> createDietDataMap(UUID dietUuid, DietDto dietDto, MemberResponseDto memberResponseDto, InbodyResponseDto inbodyResponseDto, ExerciseResponseDto exerciseResponseDto) {
         Map<String, Object> dataMap = new HashMap<>();
         // diet info
         dataMap.put("dietUuid", dietUuid);
@@ -46,6 +47,7 @@ public class GptService {
         dataMap.put("basalMetabolicRate", inbodyResponseDto.getBasalMetabolicRate());
         dataMap.put("bodyFatPercentage", inbodyResponseDto.getBodyFatPercentage());
         dataMap.put("muscleMass", inbodyResponseDto.getMuscleMass());
+        dataMap.put("exercisePurpose", exerciseResponseDto.getExercisePurpose());
         return dataMap;
     }
 
@@ -58,14 +60,13 @@ public class GptService {
         return new ResponseEntity<>(body, HttpStatus.CREATED);
     }
 
-    public ResponseEntity<InbodyFeedbackResponseDto> createInbodyFeedback(UUID inbodyUuid, InbodyResponseDto inbodyResponseDto, MemberResponseDto memberResponseDto) {
-        Map<String, Object> dataMap = createInbodyDataMap(inbodyUuid, inbodyResponseDto, memberResponseDto);
+    public ResponseEntity<InbodyFeedbackResponseDto> createInbodyFeedback(UUID inbodyUuid, InbodyResponseDto inbodyResponseDto, MemberResponseDto memberResponseDto, ExerciseResponseDto exerciseResponseDto) {
+        Map<String, Object> dataMap = createInbodyDataMap(inbodyUuid, inbodyResponseDto, memberResponseDto, exerciseResponseDto);
         ResponseEntity<InbodyFeedbackResponseDto> responseEntity = exchangeInbodyData(dataMap);
         return responseEntity;
     }
 
-    // TODO: Add Exercise info
-    private Map<String, Object> createInbodyDataMap(UUID inbodyUuid, InbodyResponseDto inbodyResponseDto, MemberResponseDto memberResponseDto) {
+    private Map<String, Object> createInbodyDataMap(UUID inbodyUuid, InbodyResponseDto inbodyResponseDto, MemberResponseDto memberResponseDto, ExerciseResponseDto exerciseResponseDto) {
         Map<String, Object> dataMap = new HashMap<>();
         // member and inbody info
         dataMap.put("inbodyUuid", inbodyUuid);
@@ -76,6 +77,7 @@ public class GptService {
         dataMap.put("bodyFatPercentage", inbodyResponseDto.getBodyFatPercentage());
         dataMap.put("muscleMass", inbodyResponseDto.getMuscleMass());
         dataMap.put("gender", memberResponseDto.getGender());
+        dataMap.put(("exercisePurpose"), exerciseResponseDto.getExercisePurpose());
         return dataMap;
     }
 

--- a/src/main/java/com/f_log/flog/gpt/GptService.java
+++ b/src/main/java/com/f_log/flog/gpt/GptService.java
@@ -1,5 +1,6 @@
 package com.f_log.flog.gpt;
 
+import com.f_log.flog.diet.dto.DailyIntakeDto;
 import com.f_log.flog.diet.dto.DietDto;
 import com.f_log.flog.dietfeedback.dto.DietFeedbackDto;
 import com.f_log.flog.exercise.dto.ExerciseResponseDto;
@@ -11,6 +12,7 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -21,25 +23,26 @@ public class GptService {
 
     private final RestTemplate restTemplate;
 
-    public ResponseEntity<DietFeedbackDto> createDietFeedback(UUID dietUuid, DietDto dietDto, MemberResponseDto memberResponseDto, InbodyResponseDto inbodyResponseDto, ExerciseResponseDto exerciseResponseDto) {
-        Map<String, Object> dataMap = createDietDataMap(dietUuid, dietDto, memberResponseDto, inbodyResponseDto, exerciseResponseDto);
+    public ResponseEntity<DietFeedbackDto> createDietFeedback(LocalDate date, MemberResponseDto memberResponseDto, DailyIntakeDto dailyIntakeDto, InbodyResponseDto inbodyResponseDto, ExerciseResponseDto exerciseResponseDto) {
+        Map<String, Object> dataMap = createDietDataMap(date, memberResponseDto, dailyIntakeDto, inbodyResponseDto, exerciseResponseDto);
         ResponseEntity<DietFeedbackDto> responseEntity = exchangeDietData(dataMap);
         return responseEntity;
     }
 
-    private Map<String, Object> createDietDataMap(UUID dietUuid, DietDto dietDto, MemberResponseDto memberResponseDto, InbodyResponseDto inbodyResponseDto, ExerciseResponseDto exerciseResponseDto) {
+    private Map<String, Object> createDietDataMap(LocalDate date, MemberResponseDto memberResponseDto, DailyIntakeDto dailyIntakeDto, InbodyResponseDto inbodyResponseDto, ExerciseResponseDto exerciseResponseDto) {
         Map<String, Object> dataMap = new HashMap<>();
         // diet info
-        dataMap.put("dietUuid", dietUuid);
-        dataMap.put("totalCarbohydrate", dietDto.getTotalCarbohydrate());
-        dataMap.put("totalProtein", dietDto.getTotalProtein());
-        dataMap.put("totalSodium", dietDto.getTotalSodium());
-        dataMap.put("totalFat", dietDto.getTotalFat());
-        dataMap.put("totalCholesterol", dietDto.getTotalCholesterol());
-        dataMap.put("totalSugars", dietDto.getTotalSugars());
-        dataMap.put("totalCalories", dietDto.getTotalCalories());
+        dataMap.put("date", date);
+        dataMap.put("totalCarbohydrate", dailyIntakeDto.getTotalCarbohydrate());
+        dataMap.put("totalProtein", dailyIntakeDto.getTotalProtein());
+        dataMap.put("totalSodium", dailyIntakeDto.getTotalSodium());
+        dataMap.put("totalFat", dailyIntakeDto.getTotalFat());
+        dataMap.put("totalCholesterol", dailyIntakeDto.getTotalCholesterol());
+        dataMap.put("totalSugars", dailyIntakeDto.getTotalSugars());
+        dataMap.put("totalCalories", dailyIntakeDto.getTotalCalories());
 
         // member and inbody info
+        dataMap.put("memberUuid", memberResponseDto.getUuid());
         dataMap.put("gender", memberResponseDto.getGender());
         dataMap.put("height", inbodyResponseDto.getHeight());
         dataMap.put("bodyWeight", inbodyResponseDto.getBodyWeight());


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
✅ 기능 추가

### 반영 브랜치
ex) feat/#63 -> main

### 변경 사항
- ExerciseService.getExercise() 메소드 반환 타입을 기존 Optional<>에서 ExerciseResponseDto로 변경
- DietFeedback 및 InbodyFeedback에 Exercise 정보를 같이 넘기도록 json payload에 추가
- DietFeedback 재정의에 따라 Diet와의 기존 1:1 관계 해제