### PR TITLE
fix: React 서버에서 GPT InbodyFeedback 생성 요청 시 UUID값이 문자열로 전송되는 오류

### DIFF
--- a/src/main/java/com/f_log/flog/gpt/controller/GptController.java
+++ b/src/main/java/com/f_log/flog/gpt/controller/GptController.java
@@ -11,6 +11,7 @@ import com.f_log.flog.exercise.dto.ExerciseResponseDto;
 import com.f_log.flog.exercise.service.ExerciseService;
 import com.f_log.flog.gpt.dto.CreateDailyDietFeedbackRequest;
 import com.f_log.flog.gpt.dto.CreateDietFeedbackRequest;
+import com.f_log.flog.gpt.dto.InbodyUuidRequest;
 import com.f_log.flog.gpt.service.GptService;
 import com.f_log.flog.healthinformation.dto.HealthInformationResponseDto;
 import com.f_log.flog.healthinformation.service.HealthInformationService;
@@ -66,7 +67,8 @@ public class GptController {
     }
 
     @PostMapping("/inbody-feedback")
-    public ResponseEntity<InbodyFeedbackResponseDto> createInbodyFeedback(@RequestBody UUID inbodyUuid) {
+    public ResponseEntity<InbodyFeedbackResponseDto> createInbodyFeedback(@RequestBody InbodyUuidRequest request) {
+        UUID inbodyUuid = request.getInbodyUuid();
         InbodyResponseDto foundInbody = inbodyService.getInbodyByUuid(inbodyUuid);
         MemberResponseDto foundMember = memberService.getMemberByUuid(foundInbody.getMemberUuid());
         ExerciseResponseDto foundExercise = exerciseService.getExercise(foundMember.getUuid());

--- a/src/main/java/com/f_log/flog/gpt/dto/InbodyUuidRequest.java
+++ b/src/main/java/com/f_log/flog/gpt/dto/InbodyUuidRequest.java
@@ -1,0 +1,16 @@
+package com.f_log.flog.gpt.dto;
+
+import java.util.UUID;
+
+public class InbodyUuidRequest {
+    private UUID inbodyUuid;
+
+    // 기본 생성자 및 getter/setter
+    public UUID getInbodyUuid() {
+        return inbodyUuid;
+    }
+
+    public void setInbodyUuid(UUID inbodyUuid) {
+        this.inbodyUuid = inbodyUuid;
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
✅ 버그 수정

### 반영 브랜치
ex) fix/#80 -> main

### 변경 사항
ResponseBody로 UUID가 아닌 새로 정의된 DTO로 받도록 변경