### PR TITLE
fix: Diet와 DietFood간의 연관관계로 인한 삭제에서 soft delete가 정상적으로 작동하도록 구현

### DIFF
--- a/src/main/java/com/f_log/flog/diet/controller/DietController.java
+++ b/src/main/java/com/f_log/flog/diet/controller/DietController.java
@@ -12,7 +12,6 @@ import com.f_log.flog.s3bucket.dto.FileUploadResponse;
 import com.f_log.flog.s3bucket.service.S3Uploader;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -110,7 +109,7 @@ public class DietController {
 
     @GetMapping("/{dietUuid}")
     public ResponseEntity<DietDto> getDiet(@PathVariable UUID dietUuid) {
-        DietDto dietDto = dietService.getDietByUuid(dietUuid);
+        DietDto dietDto = dietService.getDietDtoWithNonDeletedDietFoods(dietUuid);
         return ResponseEntity.ok(dietDto);
     }
 

--- a/src/main/java/com/f_log/flog/diet/domain/Diet.java
+++ b/src/main/java/com/f_log/flog/diet/domain/Diet.java
@@ -151,7 +151,7 @@ public class Diet extends BaseEntity {
     }
 
     public void removeDietFood(DietFood dietFood) {
-        this.dietFoods.remove(dietFood);
+        dietFood.setDeleted();
         subtractNutrients(
                 dietFood.getFood().getCarbohydrate() * dietFood.getQuantity(),
                 dietFood.getFood().getProtein() * dietFood.getQuantity(),
@@ -162,4 +162,14 @@ public class Diet extends BaseEntity {
                 dietFood.getFood().getCalories() * dietFood.getQuantity()
         );
     }
+
+    // override BaseEntity's setDeleted
+    @Override
+    public void setDeleted(){
+        super.setDeleted();
+        for (DietFood dietFood : this.dietFoods) {
+            removeDietFood(dietFood);
+        }
+    }
+
 }

--- a/src/main/java/com/f_log/flog/dietfood/service/DietFoodService.java
+++ b/src/main/java/com/f_log/flog/dietfood/service/DietFoodService.java
@@ -83,6 +83,7 @@ public class DietFoodService {
                 .dietUuid(dietFood.getDiet().getDietUuid())
                 .foodUuid(dietFood.getFood().getFoodUuid())
                 .quantity(dietFood.getQuantity())
+                .foodName(dietFood.getFoodName())
                 .notes(dietFood.getNotes())
                 .build();
     }
@@ -147,13 +148,11 @@ public class DietFoodService {
 
         // Soft delete the DietFood
         dietFood.setDeleted();
-        dietFoodRepository.save(dietFood); // Note: This assumes your repository respects the soft delete in fetch operations
 
         // Retrieve and update the associated Diet
         Diet diet = dietFood.getDiet();
-        if (diet != null) { // Check if DietFood had an associated Diet
-            diet.removeDietFood(dietFood); // This method updates the diet's nutritional info and removes the DietFood from the list
-            dietRepository.save(diet);
+        if (diet != null) {
+            diet.removeDietFood(dietFood);
         }
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
✅ 버그 수정

### 반영 브랜치
ex) feat/#90 -> main

### 변경 사항
- Diet와 DietFood간의 연관관계로 인한 삭제에서 soft delete가 정상적으로 작동하도록 구현
- DietFood GET 메소드 시 요구되는 API 스펙에서 누락된 항목을 추가 (DietFoodService.findDietFood() method)
- Diet 클래스에서 setDeleted() 메소드를 오버라이딩해서 기능에 맞도록 삭제 로직을 재정의